### PR TITLE
Fix dataset paths using os.path.join

### DIFF
--- a/DataPreProcess.py
+++ b/DataPreProcess.py
@@ -15,8 +15,8 @@ MultiModal_data_list = ['mACStatus', 'mActivity', 'mAmbience', 'mBle', 'mGps', '
 
 MultiModal_data_with_time = ['mGps', 'mLight', 'mScreenStatus', 'wHr', 'wLight', 'wPedo']
 
-metrics_train = pd.read_csv('Data\ch2025_metrics_train.csv')
-sample_submission = pd.read_csv('Data\ch2025_submission_sample.csv')
+metrics_train = pd.read_csv(os.path.join('Data', 'ch2025_metrics_train.csv'))
+sample_submission = pd.read_csv(os.path.join('Data', 'ch2025_submission_sample.csv'))
 
 top_10_labels = [
     "Inside, small room", "Speech", "Silence", "Music",
@@ -53,7 +53,7 @@ def preprocess_data(df: pd.DataFrame, timestamp_col: str = 'timestamp', SD: Opti
         np.random.seed(SD)
         os.environ['PYTHONHASHSEED'] = str(SD)
 
-    data_dir = "Data\ch2025_data_items"
+    data_dir = os.path.join('Data','ch2025_data_items')
 
     # Parquet 파일 전체 경로 리스트
     parquet_files = glob.glob(os.path.join(data_dir, 'ch2025_*.parquet'))

--- a/TimeSeriesDataPreProcess.py
+++ b/TimeSeriesDataPreProcess.py
@@ -412,7 +412,7 @@ def preprocessing():
             interpolated_results = pkl.load(f)
             print("✅ File Loaded")
     else:
-        data_dir = "Data\ch2025_data_items"
+        data_dir = os.path.join('Data', 'ch2025_data_items')
 
         # Parquet 파일 전체 경로 리스트
         parquet_files = glob.glob(os.path.join(data_dir, 'ch2025_*.parquet'))


### PR DESCRIPTION
## Summary
- remove OS-specific file separators in `DataPreProcess.py`
- make `TimeSeriesDataPreProcess.py` use `os.path.join`

## Testing
- `python -m py_compile DataPreProcess.py TimeSeriesDataPreProcess.py model.py ETRIDataLoader.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff3f72de4832b98c82e04eed7a92e