### PR TITLE
Fix BLE class check

### DIFF
--- a/TimeSeriesDataPreProcess.py
+++ b/TimeSeriesDataPreProcess.py
@@ -62,7 +62,7 @@ def process_mBle(df:pd.DataFrame):
                 rssi = int(device['rssi'])
                 rssi_list.append(rssi)
 
-                if str(device['device_class']) == 0:
+                if str(device['device_class']) == '0':
                     class_0_cnt += 1
                 else:
                     class_other_cnt += 1


### PR DESCRIPTION
## Summary
- fix BLE device class type comparison in `process_mBle`

## Testing
- `pip install pandas` *(fails: Could not find a version)*
- `python` test snippet *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ff3421ee4832ba1c83c5c206ebd43