### PR TITLE
Support altitude key in GPS processing

### DIFF
--- a/DataPreProcess.py
+++ b/DataPreProcess.py
@@ -289,7 +289,7 @@ def process_mGps(df: pd.DataFrame) -> pd.DataFrame:
             try:
                 lat = float(entry['lat'])
                 lon = float(entry['lon'])
-                alt = float(entry['alt'])
+                alt = float(entry.get('altitude', entry.get('alt')))
                 speed = float(entry['speed'])
 
                 latitudes.append(lat)

--- a/TimeSeriesDataPreProcess.py
+++ b/TimeSeriesDataPreProcess.py
@@ -215,7 +215,7 @@ def process_mGps(df):
 
         for entry in gps_list:
             try:
-                altitudes.append(float(entry['altitude']))
+                altitudes.append(float(entry.get('altitude', entry.get('alt'))))
                 latitudes.append(float(entry['latitude']))
                 longitudes.append(float(entry['longitude']))
                 speeds.append(float(entry['speed']))


### PR DESCRIPTION
## Summary
- update mGps preprocessors to accept both `altitude` and `alt`

## Testing
- `python -m py_compile DataPreProcess.py TimeSeriesDataPreProcess.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff3d97e58832b9bafabac89420119